### PR TITLE
fix: missing key on direct exchange selections

### DIFF
--- a/src/components/exchange/DirectExchange.tsx
+++ b/src/components/exchange/DirectExchange.tsx
@@ -3,7 +3,7 @@ import { Button } from "../ui/button";
 import { DirectExchangeSelection } from "./DirectExchangeSelection";
 
 const UCs = [
-    { name: "Computação Gráfica", ucClass: "3LEIC01" },    
+    { name: "Computação Gráfica", ucClass: "3LEIC01" },
     { name: "Sistemas Paralelos e Distribuídos", ucClass: "3LEIC01" },
     { name: "Compiladores", ucClass: "3LEIC04" },
     { name: "Inteligência Artificial", ucClass: "3LEIC01" },
@@ -16,7 +16,7 @@ export function DirectExchange() {
             <Button variant="submit" className="w-full"><CheckCircleIcon className="h-5 w-5 mr-2"></CheckCircleIcon>Submeter Troca</Button>
             {
                 UCs.map((uc) => (
-                    <DirectExchangeSelection UC={uc.name} ucClass={uc.ucClass} />
+                    <DirectExchangeSelection UC={uc.name} ucClass={uc.ucClass} key={uc.name} />
                 ))
             }
         </div>


### PR DESCRIPTION
This is in order to solve a `console.log` warning.

Keys should be used so react can better identify the objects individually and re-render the correct one.