### PR TITLE
feat: storing unit id on exchanges

### DIFF
--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -116,6 +116,7 @@ export type ImportedCourses = {
 
 export type ClassExchange = {
     course_unit: string,
+    course_unit_id: string,
     old_class: string,
     new_class: string,
     other_student: string // If the user didn't specify a student, it will be none

--- a/src/components/exchange/DirectExchangeSelection.tsx
+++ b/src/components/exchange/DirectExchangeSelection.tsx
@@ -176,6 +176,7 @@ export function DirectExchangeSelection({
                         setCurrentDirectExchange(
                             new Map(currentDirectExchange.set(uc.acronym, {
                                 course_unit: uc.acronym,
+                                course_unit_id: uc.code,
                                 old_class: "",
                                 new_class: uc.class, // auth student class
                                 other_student: student

--- a/src/pages/TimeTableScheduler.tsx
+++ b/src/pages/TimeTableScheduler.tsx
@@ -178,6 +178,8 @@ const TimeTableSchedulerPage = () => {
     })
   }
 
+  console.log("Current multiple options is: ", multipleOptions);
+
   useEffect(() => {
     if (totalSelected.length === 0) return
     StorageAPI.setOptionsStorage(multipleOptions)


### PR DESCRIPTION
Instead of just storing the name of the course unit, now it also stores the unit id